### PR TITLE
Modernize discussion and reply layout

### DIFF
--- a/branchera/components/AIPointSelectionModal.js
+++ b/branchera/components/AIPointSelectionModal.js
@@ -7,7 +7,8 @@ export default function AIPointSelectionModal({
   onClose, 
   aiPoints, 
   onPointSelected,
-  discussionTitle 
+  discussionTitle,
+  contextLabel
 }) {
   const [selectedPoint, setSelectedPoint] = useState(null);
   const [selectedType, setSelectedType] = useState('agree');
@@ -54,7 +55,13 @@ export default function AIPointSelectionModal({
             </button>
           </div>
           <p className="text-sm text-gray-600 mt-2">
-            Select a key point from &ldquo;{discussionTitle}&rdquo; to respond to:
+            {contextLabel ? (
+              <>
+                Select a key point from &ldquo;{contextLabel}&rdquo; to respond to:
+              </>
+            ) : (
+              <>Select a key point from &ldquo;{discussionTitle}&rdquo; to respond to:</>
+            )}
           </p>
         </div>
 

--- a/branchera/hooks/useDatabase.js
+++ b/branchera/hooks/useDatabase.js
@@ -232,6 +232,34 @@ export function useDatabase() {
     }
   };
 
+  // Update AI points for a specific reply within a discussion
+  const updateReplyAIPoints = async (discussionId, replyId, aiPoints) => {
+    try {
+      console.log('Updating AI points for reply:', replyId, 'in discussion:', discussionId);
+
+      const discussion = await getDocument('discussions', discussionId);
+      if (!discussion) {
+        throw new Error('Discussion not found');
+      }
+
+      const updatedReplies = (discussion.replies || []).map((reply) =>
+        reply.id === replyId
+          ? { ...reply, aiPoints: aiPoints || [], aiPointsGenerated: true }
+          : reply
+      );
+
+      await updateDocument('discussions', discussionId, {
+        replies: updatedReplies
+      });
+
+      console.log('Reply AI points updated successfully');
+      return true;
+    } catch (error) {
+      console.error('Error updating reply AI points:', error);
+      throw error;
+    }
+  };
+
   // Get AI points for a discussion
   const getAIPoints = async (discussionId) => {
     try {
@@ -255,6 +283,7 @@ export function useDatabase() {
     deleteReply,
     updateAIPoints,
     getAIPoints,
-    setupDatabase
+    setupDatabase,
+    updateReplyAIPoints
   };
 }


### PR DESCRIPTION
Make `AIPointSelectionModal` generic and add database support for reply-specific AI points.

This enables the upcoming feature of generating and selecting AI points for replies, allowing users to respond to specific points within nested replies.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac29cbed-98db-4853-94fc-e94fdcbdf703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac29cbed-98db-4853-94fc-e94fdcbdf703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

