### PR TITLE
Fix nested replies, menu overflow, and mobile zoom

### DIFF
--- a/branchera/app/layout.js
+++ b/branchera/app/layout.js
@@ -89,7 +89,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
       </head>
       <body>
         <AuthProvider>

--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -372,13 +372,13 @@ export default function DiscussionFeed({ newDiscussion }) {
             <div className="px-4 py-3 flex items-center justify-between">
               <button
                 onClick={() => toggleDiscussion(discussion.id)}
-                className="flex items-center gap-3 text-left flex-1"
+                className="flex items-center gap-3 text-left flex-1 min-w-0"
                 title={isExpanded ? 'Collapse' : 'Expand'}
               >
                 <svg className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-90' : ''}`} viewBox="0 0 24 24" fill="none" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
-                <span className="font-semibold text-gray-900 truncate">{discussion.title}</span>
+                <span className="font-semibold text-gray-900 truncate flex-1 min-w-0">{discussion.title}</span>
               </button>
               <div className="flex items-center gap-4">
                 <button

--- a/branchera/components/ReplyTree.js
+++ b/branchera/components/ReplyTree.js
@@ -105,23 +105,10 @@ export default function ReplyTree({
     const canReply = level < maxLevel && user;
 
     return (
-      <div key={reply.id} className={`${level > 0 ? 'ml-8 mt-2' : 'mt-3'}`}>
-        {level > 0 && (
-          <div className="flex items-start">
-            <div className="flex-shrink-0 w-6 h-6 mr-2">
-              <div className="w-3 h-3 border-l border-b border-black rounded-bl-sm"></div>
-            </div>
-            <div className="flex-1">
-              {renderReplyContent(reply, level, hasChildren, isExpanded, canReply)}
-            </div>
-          </div>
-        )}
-
-        {level === 0 && renderReplyContent(reply, level, hasChildren, isExpanded, canReply)}
-
+      <div key={reply.id} className={`${level > 0 ? 'ml-4 mt-2' : 'mt-3'}`}>
+        {renderReplyContent(reply, level, hasChildren, isExpanded, canReply)}
         {hasChildren && isExpanded && (
-          <div className="relative">
-            <div className="absolute left-3 top-0 bottom-0 w-px bg-black/60"></div>
+          <div className="ml-4 mt-2">
             {reply.children.map(childReply => renderReply(childReply, level + 1))}
           </div>
         )}
@@ -131,7 +118,7 @@ export default function ReplyTree({
 
   const renderReplyContent = (reply, level, hasChildren, isExpanded, canReply) => {
     return (
-      <div className={`rounded p-3 border-l-2 ${getReplyTypeStyle(reply.type)} ${level === 0 ? '' : 'border border-black/20'}`}>
+      <div className={`rounded border border-black/15 bg-white p-3 pl-3 border-l-2 ${getReplyTypeStyle(reply.type)}`}>
         <div className="flex items-center gap-3 mb-2">
           <span className="text-base">{getReplyTypeIcon(reply.type)}</span>
           {reply.authorPhoto ? (
@@ -192,9 +179,8 @@ export default function ReplyTree({
         <div>
           <p className="text-gray-900 text-sm whitespace-pre-wrap leading-relaxed">{reply.content}</p>
         </div>
-        {/* If reply has AI points, show a compact list to anchor sub-replies */}
         {Array.isArray(reply.aiPoints) && reply.aiPoints.length > 0 && (
-          <div className="mt-2 border border-black/20 rounded p-2">
+          <div className="mt-2 border border-black/15 rounded p-2 bg-white">
             <div className="text-[11px] font-semibold text-gray-900 mb-1">Reply points</div>
             <ul className="space-y-1">
               {reply.aiPoints.map((p) => (

--- a/branchera/components/ReplyTree.js
+++ b/branchera/components/ReplyTree.js
@@ -77,29 +77,24 @@ export default function ReplyTree({
     return rootReplies;
   };
 
-  // Group replies by AI point
-  const groupRepliesByPoint = (replies) => {
+  // Group ROOT replies by AI point, keeping full child chains regardless of their own point
+  const groupRootRepliesByPoint = (rootReplies) => {
     const grouped = {
       withPoints: {},
       general: []
     };
 
-    replies.forEach(reply => {
-      if (reply.replyToPointId) {
-        if (!grouped.withPoints[reply.replyToPointId]) {
-          grouped.withPoints[reply.replyToPointId] = [];
+    rootReplies.forEach((root) => {
+      const pointId = root.replyToPointId;
+      if (pointId) {
+        if (!grouped.withPoints[pointId]) {
+          grouped.withPoints[pointId] = [];
         }
-        grouped.withPoints[reply.replyToPointId].push(reply);
+        grouped.withPoints[pointId].push(root);
       } else {
-        grouped.general.push(reply);
+        grouped.general.push(root);
       }
     });
-
-    // Build tree structure for each group
-    Object.keys(grouped.withPoints).forEach(pointId => {
-      grouped.withPoints[pointId] = buildReplyTree(grouped.withPoints[pointId]);
-    });
-    grouped.general = buildReplyTree(grouped.general);
 
     return grouped;
   };
@@ -215,7 +210,8 @@ export default function ReplyTree({
     );
   };
 
-  const groupedReplies = groupRepliesByPoint(replies);
+  const rootReplies = buildReplyTree(replies);
+  const groupedReplies = groupRootRepliesByPoint(rootReplies);
 
   return (
     <div className="space-y-4">

--- a/branchera/components/TextReplyForm.js
+++ b/branchera/components/TextReplyForm.js
@@ -84,13 +84,13 @@ export default function TextReplyForm({
   };
 
   return (
-    <div className="bg-white rounded border border-black/20 p-3">
+    <div className="bg-white rounded border border-black/15 p-3">
       {selectedPoint ? (
         <div className="mb-3">
           <div className="text-xs font-semibold text-gray-900 mb-1">
             {getReplyTypeIcon(replyType)} {getReplyTypeLabel(replyType)}
           </div>
-          <div className="p-2 rounded border-l-2 border-black bg-white">
+          <div className="p-2 rounded border border-black/15 bg-white">
             <p className="text-xs text-gray-900">{selectedPoint.text}</p>
           </div>
         </div>
@@ -99,7 +99,7 @@ export default function TextReplyForm({
           <div className="text-xs font-semibold text-gray-900 mb-1">
             💬 Replying to {replyingToReply.authorName}
           </div>
-          <div className="p-2 rounded border-l-2 border-black bg-white">
+          <div className="p-2 rounded border border-black/15 bg-white">
             <p className="text-xs text-gray-900">{replyingToReply.content}</p>
           </div>
         </div>


### PR DESCRIPTION
Correct deep reply threading, prevent collapsed discussion title overflow, and disable initial iPhone page zoom.

- **Reply Threading:** Deep replies were not correctly related because replies were grouped by AI point *before* the full reply tree was built. This change ensures the complete reply tree is constructed first, then only the root replies are grouped by AI point, preserving all nested parent-child relationships.
- **Menu Overflow:** Collapsed discussion titles could overflow their container. `min-w-0` and `flex-1` were added to the title span and its parent button to ensure proper truncation.
- **iPhone Zoom:** The viewport meta tag was updated to `maximum-scale=1, user-scalable=no` to prevent unwanted initial zooming on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-241b64c3-5284-4eeb-a9ce-25866637c92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-241b64c3-5284-4eeb-a9ce-25866637c92e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

