### PR TITLE
Fix reply box styling inconsistencies

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -656,7 +656,7 @@ export default function DiscussionFeed({ newDiscussion }) {
 
                 {/* AI points (collapsible and clickable) */}
                 {discussion.aiPoints && discussion.aiPoints.length > 0 && (
-                  <div className="mt-2 mb-2 rounded border border-black/20">
+                  <div className="mt-2 mb-2 rounded-lg border border-black/20">
                     <button
                       onClick={() => toggleAIPoints(discussion.id)}
                       className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-50"
@@ -679,7 +679,7 @@ export default function DiscussionFeed({ newDiscussion }) {
                             <button
                               key={point.id}
                               onClick={() => handlePointClick(discussion, point)}
-                              className="w-full flex items-start gap-2 p-3 text-left rounded hover:bg-gray-50 border border-transparent hover:border-black/20"
+                              className="w-full flex items-start gap-2 p-3 text-left rounded-lg hover:bg-gray-50 border border-transparent hover:border-black/20"
                               disabled={!user}
                             >
                               <div className="w-1 h-1 bg-black rounded-full mt-2 flex-shrink-0"></div>

--- a/branchera/components/FactCheckResults.js
+++ b/branchera/components/FactCheckResults.js
@@ -8,7 +8,7 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
 
   if (isLoading) {
     return (
-      <div className="bg-white rounded border border-black/20 p-3 mt-3">
+      <div className="bg-white rounded-lg border border-black/20 p-3 mt-3">
         <div className="flex items-center gap-2 mb-2">
           <div className="w-4 h-4 border-2 border-black border-t-transparent rounded-full animate-spin"></div>
           <span className="text-sm font-semibold text-gray-900">Fact-checking content...</span>
@@ -20,7 +20,7 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
 
   if (!factCheckResults || !factCheckResults.claims || factCheckResults.claims.length === 0) {
     return (
-      <div className="bg-white rounded border border-black/20 p-3 mt-3">
+      <div className="bg-white rounded-lg border border-black/20 p-3 mt-3">
         <div className="flex items-center gap-2 mb-1">
           <svg className="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -77,7 +77,7 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
   };
 
   return (
-    <div className="bg-white rounded border border-black/20 mt-3">
+    <div className="bg-white rounded-lg border border-black/20 mt-3">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
         className="w-full flex items-center justify-between p-3 text-left hover:bg-gray-50"
@@ -100,7 +100,7 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
         {factCheckResults.claims.map((claim) => {
           const isExpanded = expandedClaims.has(claim.id);
           return (
-            <div key={claim.id} className={`border rounded p-2 ${getStatusColor(claim.status)}`}>
+            <div key={claim.id} className={`border rounded-lg p-2 ${getStatusColor(claim.status)}`}>
               <div className="flex items-start gap-2">
                 {getStatusIcon(claim.status)}
                 <div className="flex-1 min-w-0">
@@ -108,13 +108,13 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
                     <p className="text-xs font-medium text-gray-900 truncate pr-2">
                       &ldquo;{claim.text}&rdquo;
                     </p>
-                    <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 bg-white rounded">
+                    <span className="text-[10px] font-semibold uppercase tracking-wide px-2 py-0.5 bg-white rounded-full">
                       {getStatusLabel(claim.status)}
                     </span>
                   </div>
                   
                   {claim.originalPoint && (
-                    <div className="mt-1 p-1.5 bg-gray-100 rounded text-[10px] text-gray-600">
+                    <div className="mt-1 p-1.5 bg-gray-100 rounded-lg text-[10px] text-gray-600">
                       <span className="font-medium">From point:</span> {claim.originalPoint}
                     </div>
                   )}
@@ -143,7 +143,7 @@ export default function FactCheckResults({ factCheckResults, isLoading = false }
                   </div>
                   <div className="space-y-1">
                     {claim.webSearchResults.results.map((result, idx) => (
-                      <div key={idx} className="bg-white rounded border border-gray-200 p-2">
+                      <div key={idx} className="bg-white rounded-lg border border-gray-200 p-2">
                         <div className="text-[11px] font-medium text-gray-900 mb-1">
                           {result.url !== '#' ? (
                             <a 

--- a/branchera/components/ReplyTree.js
+++ b/branchera/components/ReplyTree.js
@@ -133,7 +133,7 @@ export default function ReplyTree({
 
   const renderReplyContent = (reply, level, hasChildren, isExpanded, canReply) => {
     return (
-      <div className={`rounded border border-black/20 bg-white p-3 pl-3 border-l-2 ${getReplyTypeStyle(reply.type)}`}>
+      <div className={`rounded-lg border border-black/20 bg-white p-3 pl-3 border-l-2 ${getReplyTypeStyle(reply.type)}`}>
         <div className="flex items-center gap-3 mb-2">
           <span className="text-base">{getReplyTypeIcon(reply.type)}</span>
           {reply.authorPhoto ? (
@@ -213,14 +213,14 @@ export default function ReplyTree({
         )}
         
         {Array.isArray(reply.aiPoints) && reply.aiPoints.length > 0 && (
-          <div className="mt-2 border border-black/15 rounded p-3 bg-white">
+          <div className="mt-2 border border-black/15 rounded-lg p-3 bg-white">
             <div className="text-xs font-semibold text-gray-900 mb-1">Reply points</div>
             <ul className="space-y-1">
               {reply.aiPoints.map((p) => (
                 <li key={p.id}>
                   <button
                     onClick={() => onPointClick && onPointClick(reply, p)}
-                    className="w-full flex items-start gap-2 p-2 text-left rounded hover:bg-gray-50 border border-transparent hover:border-black/20"
+                    className="w-full flex items-start gap-2 p-2 text-left rounded-lg hover:bg-gray-50 border border-transparent hover:border-black/20"
                     disabled={!user || !onPointClick}
                   >
                     <div className="w-1 h-1 bg-black rounded-full mt-2 flex-shrink-0"></div>
@@ -257,7 +257,7 @@ export default function ReplyTree({
         return (
           <div key={pointId} className="space-y-2">
             {point && (
-              <div className="border border-black/20 rounded p-3 bg-white">
+              <div className="border border-black/20 rounded-lg p-3 bg-white">
                 <div className="flex items-start gap-2">
                   <div className="w-1 h-1 bg-black rounded-full mt-2 flex-shrink-0"></div>
                   <div>

--- a/branchera/components/TextDiscussionForm.js
+++ b/branchera/components/TextDiscussionForm.js
@@ -124,7 +124,7 @@ export default function TextDiscussionForm({ onDiscussionCreated }) {
   };
 
   return (
-    <div className="bg-white rounded border border-black/20 p-6 mb-6">
+    <div className="bg-white rounded-lg border border-black/20 p-6 mb-6">
       <h2 className="text-lg font-semibold text-gray-900 mb-4">Start a Discussion</h2>
       
       <form onSubmit={handleSubmit}>
@@ -143,7 +143,7 @@ export default function TextDiscussionForm({ onDiscussionCreated }) {
               }
             }}
             placeholder="What would you like to discuss?"
-            className={`w-full px-3 py-2 border rounded focus:outline-none focus:ring-1 focus:ring-black ${
+            className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-1 focus:ring-black ${
               title.length > TITLE_CHAR_LIMIT * 0.9 ? 'border-red-400' : 'border-black/20'
             }`}
             disabled={isSubmitting}
@@ -172,7 +172,7 @@ export default function TextDiscussionForm({ onDiscussionCreated }) {
             onChange={(e) => setContent(e.target.value)}
             placeholder="Share your thoughts, ideas, or questions..."
             rows={4}
-            className="w-full px-3 py-2 border border-black/20 rounded focus:outline-none focus:ring-1 focus:ring-black resize-vertical"
+            className="w-full px-3 py-2 border border-black/20 rounded-lg focus:outline-none focus:ring-1 focus:ring-black resize-vertical"
             disabled={isSubmitting}
             required
           />
@@ -186,7 +186,7 @@ export default function TextDiscussionForm({ onDiscussionCreated }) {
           <button
             type="submit"
             disabled={isSubmitting || !title.trim() || !content.trim()}
-            className="px-6 py-2 bg-black text-white rounded hover:bg-black/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            className="px-6 py-2 bg-black text-white rounded-lg hover:bg-black/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {isSubmitting ? (
               <>

--- a/branchera/components/TextReplyForm.js
+++ b/branchera/components/TextReplyForm.js
@@ -114,14 +114,14 @@ export default function TextReplyForm({
   };
 
   return (
-    <div className="bg-white rounded border border-black/20 p-3">
+    <div className="bg-white rounded-lg border border-black/20 p-3">
       {selectedPoint ? (
         <div className="mb-3">
           <div className="text-xs font-semibold text-gray-900 mb-1">
             {getReplyTypeIcon(replyType)} {getReplyTypeLabel(replyType)}
             {selectedReplyForPoints && ` ${selectedReplyForPoints.authorName}'s point`}
           </div>
-          <div className="p-3 rounded border border-black/15 bg-white">
+          <div className="p-3 rounded-lg border border-black/15 bg-white">
             <p className="text-xs text-gray-900">{selectedPoint.text}</p>
             {selectedReplyForPoints && (
               <div className="mt-2 pt-2 border-t border-black/10">
@@ -138,7 +138,7 @@ export default function TextReplyForm({
           <div className="text-xs font-semibold text-gray-900 mb-1">
             💬 Replying to {replyingToReply.authorName}
           </div>
-          <div className="p-3 rounded border border-black/15 bg-white">
+          <div className="p-3 rounded-lg border border-black/15 bg-white">
             <p className="text-xs text-gray-900">{replyingToReply.content}</p>
           </div>
         </div>
@@ -153,7 +153,7 @@ export default function TextReplyForm({
             onChange={(e) => setContent(e.target.value)}
             placeholder="Write your reply..."
             rows={3}
-            className="w-full px-3 py-2 border border-black/20 rounded focus:outline-none focus:ring-1 focus:ring-black resize-vertical text-sm text-gray-900"
+            className="w-full px-3 py-2 border border-black/20 rounded-lg focus:outline-none focus:ring-1 focus:ring-black resize-vertical text-sm text-gray-900"
             disabled={isSubmitting}
             required
           />
@@ -166,14 +166,14 @@ export default function TextReplyForm({
             type="button"
             onClick={onCancel}
             disabled={isSubmitting}
-            className="px-3 py-1 text-sm border border-black/30 rounded hover:bg-black/5 disabled:opacity-50"
+            className="px-3 py-1 text-sm border border-black/30 rounded-lg hover:bg-black/5 disabled:opacity-50"
           >
             Cancel
           </button>
           <button
             type="submit"
             disabled={isSubmitting || !content.trim()}
-            className="px-4 py-1 text-sm bg-black text-white rounded hover:bg-black/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            className="px-4 py-1 text-sm bg-black text-white rounded-lg hover:bg-black/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
           >
             {isSubmitting ? (
               <>


### PR DESCRIPTION
Standardize border radius to `rounded-lg` for reply boxes and forms to match discussion cards.

This change addresses the inconsistency where reply boxes and related UI elements used a smaller `rounded` border radius, while main discussion cards used `rounded-lg`, leading to a disjointed visual appearance. The update ensures a uniform design across the discussion interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-771733d7-b220-415b-af2c-911f21e10835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-771733d7-b220-415b-af2c-911f21e10835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

