### PR TITLE
Style discussion box and remove emoji

### DIFF
--- a/branchera/components/ReplyTree.js
+++ b/branchera/components/ReplyTree.js
@@ -58,17 +58,7 @@ export default function ReplyTree({
     }
   };
 
-  const getReplyTypeStyle = () => 'border-l-black bg-white';
-
-  const getReplyTypeIcon = (type) => {
-    switch (type) {
-      case 'agree': return '👍';
-      case 'challenge': return '🤔';
-      case 'expand': return '💡';
-      case 'clarify': return '❓';
-      default: return '💬';
-    }
-  };
+  const getReplyTypeStyle = () => 'bg-white';
 
   // Build reply tree structure
   const buildReplyTree = (replies) => {
@@ -133,9 +123,8 @@ export default function ReplyTree({
 
   const renderReplyContent = (reply, level, hasChildren, isExpanded, canReply) => {
     return (
-      <div className={`rounded-lg border border-black/20 bg-white p-3 pl-3 border-l-2 ${getReplyTypeStyle(reply.type)}`}>
+      <div className={`rounded-lg border border-black/20 bg-white p-3 ${getReplyTypeStyle(reply.type)}`}>
         <div className="flex items-center gap-3 mb-2">
-          <span className="text-base">{getReplyTypeIcon(reply.type)}</span>
           {reply.authorPhoto ? (
             <Image
               src={reply.authorPhoto}

--- a/branchera/components/TextReplyForm.js
+++ b/branchera/components/TextReplyForm.js
@@ -98,15 +98,6 @@ export default function TextReplyForm({
     }
   };
 
-  const getReplyTypeIcon = (type) => {
-    switch (type) {
-      case 'agree': return '👍';
-      case 'challenge': return '🤔';
-      case 'expand': return '💡';
-      case 'clarify': return '❓';
-      default: return '💬';
-    }
-  };
 
   const getReplyTypeLabel = (type) => {
     // Always just say "Replying to" regardless of type
@@ -118,7 +109,7 @@ export default function TextReplyForm({
       {selectedPoint ? (
         <div className="mb-3">
           <div className="text-xs font-semibold text-gray-900 mb-1">
-            {getReplyTypeIcon(replyType)} {getReplyTypeLabel(replyType)}
+            {getReplyTypeLabel(replyType)}
             {selectedReplyForPoints && ` ${selectedReplyForPoints.authorName}'s point`}
           </div>
           <div className="p-3 rounded-lg border border-black/15 bg-white">
@@ -136,7 +127,7 @@ export default function TextReplyForm({
       ) : replyingToReply ? (
         <div className="mb-3">
           <div className="text-xs font-semibold text-gray-900 mb-1">
-            💬 Replying to {replyingToReply.authorName}
+            Replying to {replyingToReply.authorName}
           </div>
           <div className="p-3 rounded-lg border border-black/15 bg-white">
             <p className="text-xs text-gray-900">{replyingToReply.content}</p>


### PR DESCRIPTION
Refactor reply box styling to remove emojis and thick borders, matching the discussion box aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-69421ab7-a990-4ff5-9181-0dd5d72f9fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69421ab7-a990-4ff5-9181-0dd5d72f9fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

