### PR TITLE
Investigate news bot upload failure

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -178,7 +178,7 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
       console.error('Error in news post creation (non-blocking):', error);
       // This is intentionally non-blocking - errors here should never affect the main UI
     }
-  }, [user, createDiscussion, updateAIPoints, updateFactCheckResults]);
+  }, [user, createDiscussion, loadDiscussions, updateAIPoints, updateFactCheckResults]);
 
   useEffect(() => {
     loadDiscussions();


### PR DESCRIPTION
Re-add `loadDiscussions` to the `checkAndCreateNewsPost` useCallback dependency array to fix the news bot's inability to upload posts.

Removing `loadDiscussions` from the dependency array caused a React stale closure problem. The `checkAndCreateNewsPost` callback was holding stale references to functions like `createDiscussion`, `updateAIPoints`, and `updateFactCheckResults`, which likely depend on `loadDiscussions` or are recreated when `loadDiscussions` changes. Restoring it ensures the callback uses fresh function references, allowing the news bot to operate correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-babaf126-def3-41b9-b169-3f62803e6da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-babaf126-def3-41b9-b169-3f62803e6da0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

