### PR TITLE
Fix news bot article link retrieval

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -1047,7 +1047,9 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
                                 className="text-blue-600 hover:text-blue-800 underline"
                                 title={discussion.metadata.newsStory.source.urlValidated === false 
                                   ? `Original article link unavailable. This links to ${discussion.metadata.newsStory.source.name}'s website.`
-                                  : 'Read the original article'
+                                  : discussion.metadata.newsStory.source.groundingTitle 
+                                    ? `Read: ${discussion.metadata.newsStory.source.groundingTitle}`
+                                    : 'Read the original article'
                                 }
                               >
                                 {discussion.metadata.newsStory.source.urlValidated === false 


### PR DESCRIPTION
Extract actual article URLs from Google Search grounding data to fix "page not found" errors in the news bot.

The AI model was previously asked to generate URLs, which often resulted in non-existent or inaccessible links. By leveraging the Google Search grounding metadata, the system now directly pulls validated URLs, ensuring reliability and consistency with the existing fact-check functionality. This also includes a robust fallback system and UI indicators for URL validation status.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8fcca25-3fe1-4953-a7d0-0e71b5d851c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8fcca25-3fe1-4953-a7d0-0e71b5d851c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

