### PR TITLE
Adjust discussion box layout and remove icons

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -1067,25 +1067,19 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
                 {/* AI Generated Indicator with Source */}
                 {discussion.metadata?.isAIGenerated && (
                   <div className="mb-3 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                    <div className="flex items-center gap-2 text-sm mb-2">
-                      <svg className="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-                      </svg>
-                      <span className="text-blue-800 font-medium">AI-Generated Discussion</span>
+                    <div className="text-sm mb-2">
+                      <div className="text-blue-800 font-medium mb-1">AI Generated Discussion</div>
                       {discussion.metadata.newsStory?.stance && (
-                        <span className="text-blue-700">
-                          • Stance: {discussion.metadata.newsStory.stance}
-                        </span>
+                        <div className="text-blue-700">
+                          Stance: {discussion.metadata.newsStory.stance}
+                        </div>
                       )}
                     </div>
                     
                     {/* Source Information */}
                     {discussion.metadata.newsStory?.source && (
-                      <div className="flex items-start gap-2 text-xs">
-                        <svg className="w-3 h-3 text-blue-600 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
-                        </svg>
-                        <div className="text-blue-700 min-w-0 flex-1 break-words">
+                      <div className="text-xs">
+                        <div className="text-blue-700 min-w-0 break-words">
                           Based on: <strong>{discussion.metadata.newsStory.source.name}</strong>
                           {discussion.metadata.newsStory.source.url && (
                             <>


### PR DESCRIPTION
Stack the "AI Generated Discussion" heading above the stance and remove all icons from the AI-generated discussion box to improve readability and layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-da2e5f17-0f39-4bf4-b5f7-f577db597e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da2e5f17-0f39-4bf4-b5f7-f577db597e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

