### PR TITLE
Fix fact check for ai news bot posts

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -371,9 +371,9 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
   // Generate AI points for a discussion
   const generateAIPointsForDiscussion = async (discussion) => {
     try {
-      // Skip AI-generated discussions (they should already have points) and discussions that already have points
-      if (discussion.metadata?.isAIGenerated || discussion.aiPointsGenerated || (discussion.aiPoints && discussion.aiPoints.length > 0)) {
-        return; // Already has points or is AI-generated
+      // Skip discussions that already have points
+      if (discussion.aiPointsGenerated || (discussion.aiPoints && discussion.aiPoints.length > 0)) {
+        return; // Already has points
       }
 
       console.log('Generating AI points for discussion:', discussion.id);
@@ -400,9 +400,9 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
   // Generate fact-check results for a discussion based on its AI points
   const generateFactCheckForDiscussion = async (discussion) => {
     try {
-      // Skip AI-generated discussions (they should already have fact-check) and discussions that already have results
-      if (discussion.metadata?.isAIGenerated || discussion.factCheckGenerated || discussion.factCheckResults) {
-        return; // Already has fact-check results or is AI-generated
+      // Skip discussions that already have fact-check results
+      if (discussion.factCheckGenerated || discussion.factCheckResults) {
+        return; // Already has fact-check results
       }
 
       console.log('Generating fact-check results for discussion:', discussion.id);

--- a/branchera/lib/newsService.js
+++ b/branchera/lib/newsService.js
@@ -547,15 +547,14 @@ Make it punchy, specific, and debate-worthy. The source information will be disp
         console.log('Generating fact-check results for news discussion...');
         const factCheckResults = await AIService.factCheckPoints(aiPoints, post.title);
         
-        if (factCheckResults) {
-          if (updateFactCheckResults) {
-            await updateFactCheckResults(discussion.id, factCheckResults);
-            console.log('Fact-check results saved to database for news discussion');
-          }
-          discussion.factCheckResults = factCheckResults;
-          discussion.factCheckGenerated = true;
-          console.log('Fact-check results generated for news discussion');
+        // Always save fact check results, even if empty, and mark as generated
+        if (updateFactCheckResults) {
+          await updateFactCheckResults(discussion.id, factCheckResults);
+          console.log('Fact-check results saved to database for news discussion');
         }
+        discussion.factCheckResults = factCheckResults;
+        discussion.factCheckGenerated = true;
+        console.log('Fact-check results generated for news discussion');
         
       } catch (aiError) {
         console.error('Error generating AI content for news discussion:', aiError);


### PR DESCRIPTION
Enable fact-checking for AI news bot posts by removing the `isAIGenerated` skip condition and ensuring fact-check generation status is always recorded.

The `DiscussionFeed` component explicitly skipped fact-checking for any discussion marked `isAIGenerated`, assuming they would always have fact-check results from the `NewsService`. If the initial fact-check generation in `NewsService` failed or returned empty results, these AI-generated posts would never be re-processed for fact-checking. This PR fixes that by allowing `DiscussionFeed` to attempt fact-checking for AI posts if results are missing, and by ensuring `NewsService` always marks fact-check as attempted.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0fe92ca-2535-4cf8-ade2-2c5927dac09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0fe92ca-2535-4cf8-ade2-2c5927dac09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

