### PR TITLE
Trim whitespace from landing and about pages

### DIFF
--- a/branchera/app/about/page.js
+++ b/branchera/app/about/page.js
@@ -17,26 +17,26 @@ export default function AboutPage() {
         <div className="relative flex flex-col items-center justify-center min-h-screen p-4 pt-8">
           <main className="text-center max-w-6xl w-full">
             {/* Hero Section */}
-            <div className="mb-20">
-              <div className="inline-flex items-center px-4 py-2 rounded-full bg-black text-white text-sm font-medium mb-8">
+            <div className="mb-16">
+              <div className="inline-flex items-center px-4 py-2 rounded-full bg-black text-white text-sm font-medium mb-6">
                 <span className="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
                 Our Story • Our Mission • Our Values
               </div>
               
-              <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold mb-8 text-black leading-tight">
+              <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 text-black leading-tight">
                 About Branchera
               </h1>
               
-              <p className="text-xl md:text-2xl text-gray-700 font-light max-w-4xl mx-auto leading-relaxed mb-8">
+              <p className="text-xl md:text-2xl text-gray-700 font-light max-w-4xl mx-auto leading-relaxed mb-6">
                 We&rsquo;re building the social platform that puts <span className="font-semibold text-black">people before profit</span> and <span className="font-semibold text-black">dialogue before engagement</span>
               </p>
             </div>
 
             {/* Mission Statement */}
-            <div className="max-w-5xl mx-auto mb-20">
-              <div className="bg-gray-50 border-l-4 border-black p-8 rounded-r-lg">
-                <h2 className="text-2xl font-bold text-black mb-4">Our Founding Question</h2>
-                <p className="text-xl md:text-2xl text-gray-800 font-medium italic leading-relaxed mb-4">
+            <div className="max-w-5xl mx-auto mb-16">
+              <div className="bg-gray-50 border-l-4 border-black p-6 rounded-r-lg">
+                <h2 className="text-2xl font-bold text-black mb-3">Our Founding Question</h2>
+                <p className="text-xl md:text-2xl text-gray-800 font-medium italic leading-relaxed mb-3">
                   &ldquo;What if social media was about maximizing constructive dialogue instead of engagement?&rdquo;
                 </p>
                 <p className="text-lg text-gray-600 leading-relaxed">
@@ -46,9 +46,9 @@ export default function AboutPage() {
             </div>
 
             {/* Core Principles */}
-            <div className="mb-24">
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <div className="mb-20">
+              <div className="text-center mb-12">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
                   Our Core Principles
                 </h2>
                 <p className="text-lg text-gray-600 max-w-3xl mx-auto">
@@ -56,55 +56,55 @@ export default function AboutPage() {
                 </p>
               </div>
               
-              <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+              <div className="grid md:grid-cols-2 gap-6 max-w-5xl mx-auto">
                 {/* Attack Arguments, Not People */}
-                <div className="bg-white rounded-2xl p-8 border-2 border-black">
-                  <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
-                    <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <div className="bg-white rounded-2xl p-6 border-2 border-black">
+                  <div className="w-14 h-14 mx-auto mb-4 bg-black rounded-2xl flex items-center justify-center">
+                    <svg className="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
                     </svg>
                   </div>
-                  <h3 className="text-xl font-bold mb-4 text-black">&ldquo;Attack Arguments, Not People&rdquo;</h3>
+                  <h3 className="text-xl font-bold mb-3 text-black">&ldquo;Attack Arguments, Not People&rdquo;</h3>
                   <p className="text-gray-600 leading-relaxed">
                     The golden rule of constructive discourse. Challenge ideas rigorously while treating people with respect. This principle is built into our platform design and community guidelines.
                   </p>
                 </div>
 
                 {/* Transparency First */}
-                <div className="bg-white rounded-2xl p-8 border-2 border-black">
-                  <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
-                    <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <div className="bg-white rounded-2xl p-6 border-2 border-black">
+                  <div className="w-14 h-14 mx-auto mb-4 bg-black rounded-2xl flex items-center justify-center">
+                    <svg className="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                     </svg>
                   </div>
-                  <h3 className="text-xl font-bold mb-4 text-black">Radical Transparency</h3>
+                  <h3 className="text-xl font-bold mb-3 text-black">Radical Transparency</h3>
                   <p className="text-gray-600 leading-relaxed">
                     Every line of our code is open source. Every AI decision is explainable. Every fact-check shows its sources. No black boxes, no hidden algorithms, no secret sauce.
                   </p>
                 </div>
 
                 {/* Gets Out of Your Way */}
-                <div className="bg-white rounded-2xl p-8 border-2 border-black">
-                  <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
-                    <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <div className="bg-white rounded-2xl p-6 border-2 border-black">
+                  <div className="w-14 h-14 mx-auto mb-4 bg-black rounded-2xl flex items-center justify-center">
+                    <svg className="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
                     </svg>
                   </div>
-                  <h3 className="text-xl font-bold mb-4 text-black">Gets Out of Your Way</h3>
+                  <h3 className="text-xl font-bold mb-3 text-black">Gets Out of Your Way</h3>
                   <p className="text-gray-600 leading-relaxed">
                     No infinite scroll. No notification spam. No dark patterns. Clean, focused interface that helps you engage meaningfully, then get back to your life.
                   </p>
                 </div>
 
                 {/* Forever Free */}
-                <div className="bg-white rounded-2xl p-8 border-2 border-black">
-                  <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
-                    <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <div className="bg-white rounded-2xl p-6 border-2 border-black">
+                  <div className="w-14 h-14 mx-auto mb-4 bg-black rounded-2xl flex items-center justify-center">
+                    <svg className="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                     </svg>
                   </div>
-                  <h3 className="text-xl font-bold mb-4 text-black">Forever Free & Ad-Free</h3>
+                  <h3 className="text-xl font-bold mb-3 text-black">Forever Free & Ad-Free</h3>
                   <p className="text-gray-600 leading-relaxed">
                     Built as a public good, not a profit center. No ads, no premium tiers, no paywalls. Funded by community support, not by harvesting your attention or data.
                   </p>
@@ -113,15 +113,15 @@ export default function AboutPage() {
             </div>
 
             {/* The Problem We&rsquo;re Solving */}
-            <div className="mb-24">
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <div className="mb-20">
+              <div className="text-center mb-12">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
                   The Problem We&rsquo;re Solving
                 </h2>
               </div>
               
               <div className="max-w-4xl mx-auto">
-                <div className="bg-red-50 border-l-4 border-red-400 p-6 rounded-r-lg mb-8">
+                <div className="bg-red-50 border-l-4 border-red-400 p-6 rounded-r-lg mb-6">
                   <h3 className="text-xl font-bold text-red-800 mb-3">Traditional Social Media Is Broken</h3>
                   <ul className="text-red-700 space-y-2">
                     <li>• Designed to maximize engagement, not understanding</li>
@@ -148,9 +148,9 @@ export default function AboutPage() {
             </div>
 
             {/* How We&rsquo;re Different */}
-            <div className="mb-24">
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <div className="mb-20">
+              <div className="text-center mb-12">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
                   How We&rsquo;re Different
                 </h2>
                 <p className="text-lg text-gray-600 max-w-3xl mx-auto">
@@ -158,11 +158,11 @@ export default function AboutPage() {
                 </p>
               </div>
               
-              <div className="grid md:grid-cols-3 gap-8 max-w-6xl mx-auto">
+              <div className="grid md:grid-cols-3 gap-6 max-w-6xl mx-auto">
                 {/* Open Source */}
                 <div className="text-center">
-                  <div className="w-20 h-20 mx-auto mb-6 bg-green-100 rounded-full flex items-center justify-center">
-                    <svg className="w-10 h-10 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <div className="w-16 h-16 mx-auto mb-4 bg-green-100 rounded-full flex items-center justify-center">
+                    <svg className="w-8 h-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
                     </svg>
                   </div>
@@ -174,8 +174,8 @@ export default function AboutPage() {
 
                 {/* AI-Powered Truth */}
                 <div className="text-center">
-                  <div className="w-20 h-20 mx-auto mb-6 bg-blue-100 rounded-full flex items-center justify-center">
-                    <svg className="w-10 h-10 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <div className="w-16 h-16 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
+                    <svg className="w-8 h-8 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                   </div>
@@ -187,8 +187,8 @@ export default function AboutPage() {
 
                 {/* Community Governance */}
                 <div className="text-center">
-                  <div className="w-20 h-20 mx-auto mb-6 bg-purple-100 rounded-full flex items-center justify-center">
-                    <svg className="w-10 h-10 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <div className="w-16 h-16 mx-auto mb-4 bg-purple-100 rounded-full flex items-center justify-center">
+                    <svg className="w-8 h-8 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                     </svg>
                   </div>
@@ -201,12 +201,12 @@ export default function AboutPage() {
             </div>
 
             {/* Call to Action */}
-            <div className="relative mb-20">
-              <div className="bg-gradient-to-br from-gray-50 to-white rounded-3xl p-12 border border-black/20 max-w-4xl mx-auto text-center">
-                <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black">
+            <div className="relative mb-16">
+              <div className="bg-gradient-to-br from-gray-50 to-white rounded-3xl p-10 border border-black/20 max-w-4xl mx-auto text-center">
+                <h2 className="text-3xl md:text-4xl font-bold mb-4 text-black">
                   Join the Movement
                 </h2>
-                <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto leading-relaxed">
+                <p className="text-xl text-gray-600 mb-6 max-w-2xl mx-auto leading-relaxed">
                   Be part of building social media that serves humanity, not corporate profits. Help us prove that constructive dialogue can thrive online.
                 </p>
                 
@@ -228,7 +228,7 @@ export default function AboutPage() {
                   )}
                 </div>
                 
-                <p className="text-sm text-gray-500 mt-6">
+                <p className="text-sm text-gray-500 mt-4">
                   Free account • No ads ever • Help shape the future of social media
                 </p>
               </div>

--- a/branchera/app/page.js
+++ b/branchera/app/page.js
@@ -22,21 +22,21 @@ export default function Home() {
         <div className="relative flex flex-col items-center justify-center min-h-screen p-4 pt-8">
           <main className="text-center max-w-5xl w-full">
             {/* Brand Badge */}
-            <div className="inline-flex items-center px-4 py-2 rounded-full bg-black text-white text-sm font-medium mb-6">
+            <div className="inline-flex items-center px-4 py-2 rounded-full bg-black text-white text-sm font-medium mb-4">
               <span className="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
               Open Source • Ad-Free • Always
             </div>
             
-            <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold mb-6 text-black leading-tight">
+            <h1 className="text-5xl md:text-6xl lg:text-7xl font-bold mb-4 text-black leading-tight">
               Branchera
             </h1>
             
-            <p className="text-lg md:text-xl lg:text-2xl mb-8 text-gray-700 font-light max-w-4xl mx-auto leading-relaxed">
+            <p className="text-lg md:text-xl lg:text-2xl mb-6 text-gray-700 font-light max-w-4xl mx-auto leading-relaxed">
               The social app that <span className="font-semibold text-black">gets out of your way</span> — built for constructive dialogue, not endless scrolling
             </p>
 
             {/* Early CTA */}
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8 max-w-md mx-auto">
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-6 max-w-md mx-auto">
               <Link
                 href="/login"
                 className="flex-1 py-3 px-6 text-center bg-black text-white border-0 hover:bg-black/80 rounded-full transition-all duration-300 font-semibold text-base shadow-lg hover:shadow-xl"
@@ -51,12 +51,12 @@ export default function Home() {
               </Link>
             </div>
 
-            <p className="text-xs text-gray-500 mb-8">
+            <p className="text-xs text-gray-500 mb-6">
               Free forever • No ads • 
               <span className="font-medium text-gray-700">Join our growing community</span>
             </p>
             
-            <div className="max-w-3xl mx-auto mb-6">
+            <div className="max-w-3xl mx-auto mb-4">
               <div className="bg-gray-50 border-l-4 border-black p-4 rounded-r-lg">
                 <p className="text-base md:text-lg text-gray-800 font-medium italic leading-relaxed">
                   &ldquo;What if social media was about maximizing constructive dialogue instead of engagement?&rdquo;
@@ -65,7 +65,7 @@ export default function Home() {
               </div>
             </div>
             
-            <div className="max-w-2xl mx-auto mb-8">
+            <div className="max-w-2xl mx-auto mb-6">
               <div className="bg-black text-white p-3 rounded-lg text-center">
                 <p className="text-base font-semibold">
                   &ldquo;Attack arguments, not people.&rdquo;
@@ -74,14 +74,14 @@ export default function Home() {
               </div>
             </div>
             
-            <p className="text-base md:text-lg text-gray-600 mb-12 max-w-3xl mx-auto leading-relaxed">
+            <p className="text-base md:text-lg text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
               Experience AI-powered fact-checking, transparent discussions with smart point extraction, and a community where substance matters more than likes.
             </p>
 
             {/* Key Features */}
-            <div className="mt-24">
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <div className="mt-16">
+              <div className="text-center mb-12">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
                   A Social Platform Built Differently
                 </h2>
                 <p className="text-lg text-gray-600 max-w-3xl mx-auto">
@@ -89,7 +89,7 @@ export default function Home() {
                 </p>
               </div>
               
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-7xl mx-auto mb-16">
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto mb-12">
                 {/* Open Source & Transparent */}
                 <div className="group relative bg-white rounded-2xl p-8 border border-black/20 hover:border-black transition-all duration-300">
                   <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
@@ -131,7 +131,7 @@ export default function Home() {
               </div>
 
               {/* AI-Powered Features Row */}
-              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-7xl mx-auto">
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto">
                 {/* AI-Powered Fact Checking */}
                 <div className="group relative bg-white rounded-2xl p-8 border border-black/20 hover:border-black transition-all duration-300">
                   <div className="w-16 h-16 mx-auto mb-6 bg-black rounded-2xl flex items-center justify-center">
@@ -174,9 +174,9 @@ export default function Home() {
             </div>
 
             {/* Coming Soon Features */}
-            <div className="mt-32 mb-20">
-              <div className="text-center mb-16">
-                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
+            <div className="mt-20 mb-16">
+              <div className="text-center mb-12">
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-3">
                   Coming Soon
                 </h2>
                 <p className="text-lg text-gray-600 max-w-3xl mx-auto">
@@ -239,7 +239,7 @@ export default function Home() {
               </div>
 
               {/* Community Roadmap Note */}
-              <div className="text-center mt-12">
+              <div className="text-center mt-8">
                 <div className="inline-flex items-center px-6 py-3 rounded-full bg-black text-white text-sm font-medium">
                     <svg className="w-5 h-5 sm:w-4 sm:h-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
@@ -249,25 +249,24 @@ export default function Home() {
               </div>
             </div>
 
-
             {/* Call to Action */}
-            <div className="relative mt-20 mb-20">
+            <div className="relative mt-16 mb-16">
               <div className="bg-gradient-to-br from-gray-50 to-white rounded-3xl p-12 border border-black/20 max-w-5xl mx-auto text-center">
                 <div className="inline-flex items-center px-4 py-2 rounded-full bg-green-100 text-green-800 text-sm font-medium mb-6">
                   <span className="w-2 h-2 bg-green-500 rounded-full mr-2 animate-pulse"></span>
                   Join the Beta • Help Shape the Future
                 </div>
                 
-                <h2 className="text-3xl md:text-4xl font-bold mb-6 text-black">
+                <h2 className="text-3xl md:text-4xl font-bold mb-4 text-black">
                   Ready for Social Media That Respects Your Intelligence?
                 </h2>
                 
-                <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto leading-relaxed">
+                <p className="text-xl text-gray-600 mb-6 max-w-3xl mx-auto leading-relaxed">
                   Be part of a community that values thoughtful discourse over viral content. Where every claim is fact-checked, every discussion is transparent, and your time is respected.
                 </p>
 
                 {/* Value Props */}
-                <div className="grid md:grid-cols-3 gap-6 mb-10 max-w-4xl mx-auto">
+                <div className="grid md:grid-cols-3 gap-6 mb-8 max-w-4xl mx-auto">
                   <div className="flex items-center justify-center">
                     <svg className="w-6 h-6 sm:w-5 sm:h-5 text-green-600 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -297,7 +296,7 @@ export default function Home() {
                   </Link>
                 </div>
                 
-                <p className="text-sm text-gray-500 mt-6">
+                <p className="text-sm text-gray-500 mt-4">
                   Free account • No credit card required • 
                   <span className="font-semibold text-gray-700">Join our growing community</span> of thoughtful discussers
                 </p>


### PR DESCRIPTION
Remove excess whitespace at the top of the landing and about pages by adjusting padding and removing empty lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1cb71ce-5202-490b-b424-17ac01cc5bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1cb71ce-5202-490b-b424-17ac01cc5bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

