### PR TITLE
Adjust dashboard discussion spacing

### DIFF
--- a/branchera/components/DiscussionItem.js
+++ b/branchera/components/DiscussionItem.js
@@ -449,7 +449,7 @@ export default function DiscussionItem({
         className={`flex ${isExpanded ? '' : 'hidden'} w-full justify-end `}
         title={isExpanded ? 'Collapse' : 'Expand'}
       >
-        <svg className={`w-5 h-5 rotate-90 mr-4 mt-4`} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <svg className={`w-5 h-5 rotate-90 mr-4 mt-2`} viewBox="0 0 24 24" fill="none" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
         </svg>
       </button>
@@ -526,7 +526,7 @@ export default function DiscussionItem({
 
       {/* Expanded Content */}
       {isExpanded && (
-        <div className="px-4 pb-4 pt-4">
+        <div className="px-4 pb-4 pt-1">
           {/* Title and author info */}
           <div className="pb-2">
             <h3 className="text-lg font-semibold text-gray-900 mb-3">


### PR DESCRIPTION
Reduce excessive top spacing in expanded discussions on the dashboard.

The previous top spacing of 32px (2rem) was unbalanced. This change reduces it to 12px (0.75rem) by adjusting the collapse button's top margin (`mt-4` to `mt-2`) and the expanded content's top padding (`pt-4` to `pt-1`), resulting in a more proportional and visually appealing layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-f18ab434-7cd8-491c-ae2f-07c39e5d161a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f18ab434-7cd8-491c-ae2f-07c39e5d161a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

