### PR TITLE
Fix search results reset on discussion expand

### DIFF
--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -312,10 +312,14 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
   }, []);
 
 
-  // Initialize filtered discussions when discussions change
+  // Initialize filtered discussions when discussions change, but preserve search results
   useEffect(() => {
-    setFilteredDiscussions(discussions);
-  }, [discussions]);
+    // Only reset to show all discussions if there's no active search or filters
+    if (!searchQuery.trim() && !isUserSearching) {
+      setFilteredDiscussions(discussions);
+    }
+    // If there is an active search, let the SearchFilterSort component handle the filtering
+  }, [discussions, searchQuery, isUserSearching]);
 
   // Handle search query changes and manage searching state
   const handleSearchChange = useCallback((query) => {


### PR DESCRIPTION
Preserve search results when expanding discussions during an active search.

Previously, expanding a discussion would trigger a `useEffect` that unconditionally reset `filteredDiscussions` to show all discussions, causing active search results to disappear. This change modifies the `useEffect` to only reset `filteredDiscussions` when no search is active, allowing the `SearchFilterSort` component to maintain and re-apply search results.

---
<a href="https://cursor.com/background-agent?bcId=bc-1df6e477-9f3a-4360-af07-e7e0a5bd35c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1df6e477-9f3a-4360-af07-e7e0a5bd35c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

