### PR TITLE
Update points range and claim indicator

### DIFF
--- a/branchera/components/ReplyTree.js
+++ b/branchera/components/ReplyTree.js
@@ -269,11 +269,11 @@ export default function ReplyTree({
               )}
               {/* Visual indicator for points earned */}
               {reply.pointsEarnedByUser && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full bg-purple-100 text-purple-800 font-medium">
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full bg-green-100 text-green-800 font-medium">
                   <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
                     <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
                   </svg>
-                  Points Earned
+                  +{reply.pointsEarnedByUser} Points
                 </span>
               )}
             </div>

--- a/branchera/components/TextReplyForm.js
+++ b/branchera/components/TextReplyForm.js
@@ -146,6 +146,7 @@ export default function TextReplyForm({
                   userPhoto: user.photoURL,
                   discussionId: discussionId,
                   discussionTitle: discussionTitle,
+                  replyId: createdReply.id,
                   originalPoint: selectedPoint.text,
                   originalPointId: selectedPoint.id,
                   rebuttal: replyData.content,
@@ -344,7 +345,7 @@ export default function TextReplyForm({
       {selectedPoint && (
         <div className="mt-2 p-2 bg-purple-50 border border-purple-200 rounded-lg">
           <div className="text-xs text-purple-800">
-            💡 <strong>Earn Points:</strong> Provide a factual and coherent rebuttal to this point to earn 1-3 points! 
+            💡 <strong>Earn Points:</strong> Provide a factual and coherent response to this point to earn 1-3 points! 
             (One collection per discussion)
           </div>
         </div>

--- a/branchera/hooks/useDatabase.js
+++ b/branchera/hooks/useDatabase.js
@@ -585,6 +585,32 @@ export function useDatabase() {
     }
   };
 
+  // Enrich replies with points earned by user
+  const enrichRepliesWithPoints = async (replies, userId) => {
+    if (!replies || !userId) return replies;
+    
+    try {
+      const userPoints = await getUserPoints(userId);
+      const pointsByReplyId = new Map();
+      
+      // Create a map of reply IDs to points earned
+      userPoints.forEach(point => {
+        if (point.replyId && point.pointsEarned) {
+          pointsByReplyId.set(point.replyId, point.pointsEarned);
+        }
+      });
+      
+      // Enrich replies with points data
+      return replies.map(reply => ({
+        ...reply,
+        pointsEarnedByUser: pointsByReplyId.get(reply.id) || null
+      }));
+    } catch (error) {
+      console.error('Error enriching replies with points:', error);
+      return replies;
+    }
+  };
+
   // Check if user has collected a specific AI point
   const hasUserCollectedPoint = async (userId, discussionId, originalPointId) => {
     try {
@@ -681,6 +707,7 @@ export function useDatabase() {
     getUserPoints,
     getUserPointsForDiscussion,
     hasUserEarnedPointsForDiscussion,
+    enrichRepliesWithPoints,
     hasUserCollectedPoint,
     getLeaderboard,
     getPointCounts

--- a/branchera/lib/aiService.js
+++ b/branchera/lib/aiService.js
@@ -455,10 +455,10 @@ Do not include any explanation or additional text, just the JSON object.`;
     }
   }
 
-  // Judge rebuttal quality for points system
+  // Judge response quality for points system
   static async judgeRebuttal(originalPoint, rebuttal, parentFactCheck = null, childFactCheck = null, discussionContext = '') {
     try {
-      console.log('Judging rebuttal quality:', { originalPoint, rebuttal });
+      console.log('Judging response quality:', { originalPoint, rebuttal });
       
       const judgement = await this.performRebuttalJudgementWithFirebaseAI(
         originalPoint, 
@@ -481,10 +481,10 @@ Do not include any explanation or additional text, just the JSON object.`;
         isRelevant: true, // Assume relevance if replying to a point
         hasEvidence: false,
         isConstructive: true,
-        explanation: 'Unable to evaluate this rebuttal due to a technical issue. Your reply has been submitted successfully. Please try replying again to earn points.',
+        explanation: 'Unable to evaluate this response due to a technical issue. Your reply has been submitted successfully. Please try replying again to earn points.',
         factualConcerns: ['Technical evaluation error - please try again'],
         strengths: ['Your reply was submitted successfully'],
-        improvements: ['Try submitting your rebuttal again for point evaluation'],
+        improvements: ['Try submitting your response again for point evaluation'],
         grounding: {
           searchPerformed: false,
           searchQueries: [],
@@ -499,7 +499,7 @@ Do not include any explanation or additional text, just the JSON object.`;
     }
   }
 
-  // Firebase AI rebuttal judgement using Gemini with Google Search grounding
+  // Firebase AI response judgement using Gemini with Google Search grounding
   static async performRebuttalJudgementWithFirebaseAI(originalPoint, rebuttal, parentFactCheck, childFactCheck, discussionContext) {
     // Initialize the Firebase AI backend service
     const ai = getAI(app, { backend: new GoogleAIBackend() });
@@ -518,31 +518,31 @@ ${parentFactCheck ? `Original Point Fact Check: ${JSON.stringify(parentFactCheck
 ${childFactCheck ? `Rebuttal Fact Check: ${JSON.stringify(childFactCheck, null, 2)}` : ''}` : '';
 
     const prompt = `
-You are an AI judge evaluating whether a rebuttal deserves points in a discussion system. Users earn points by providing factual and coherent rebuttals to discussion points.
+You are an AI judge evaluating whether a response deserves points in a discussion system. Users earn points by providing factual, coherent, and constructive responses to discussion points.
 
 DISCUSSION CONTEXT: ${discussionContext}
 
-ORIGINAL POINT BEING CHALLENGED:
+ORIGINAL POINT BEING ADDRESSED:
 "${originalPoint}"
 
-USER'S REBUTTAL:
+USER'S RESPONSE:
 "${rebuttal}"
 ${factCheckInfo}
 
-Your job is to evaluate if this rebuttal deserves points based on these criteria:
+Your job is to evaluate if this response deserves points based on these criteria:
 
-1. FACTUAL ACCURACY: Is the rebuttal factually correct? Use Google Search to verify claims if needed.
-2. COHERENCE: Is the rebuttal well-structured, logical, and clearly written?
+1. FACTUAL ACCURACY: Is the response factually correct? Use Google Search to verify claims if needed.
+2. COHERENCE: Is the response well-structured, logical, and clearly written?
 3. RELEVANCE: Does it directly address the original point?
 4. EVIDENCE: Does it provide supporting evidence or reasoning?
 5. CONSTRUCTIVENESS: Does it contribute meaningfully to the discussion?
 
 SCORING SYSTEM (BE VERY STINGY WITH POINTS):
-- 3 points: EXCEPTIONAL rebuttal with comprehensive research, perfect factual accuracy from authoritative sources, sophisticated analysis, and expert-level insight that significantly advances the discussion
-- 2 points: GOOD rebuttal with solid research-backed evidence, strong factual accuracy, clear logical reasoning, and meaningful contribution to the discussion
-- 1 point: BASIC rebuttal that adequately addresses the point with some supporting evidence or reasoning, OR any rebuttal that is coherent, relevant, and constructive even if it lacks depth or comprehensive research
+- 3 points: EXCEPTIONAL response with comprehensive research, perfect factual accuracy from authoritative sources, sophisticated analysis, and expert-level insight that significantly advances the discussion
+- 2 points: GOOD response with solid research-backed evidence, strong factual accuracy, clear logical reasoning, and meaningful contribution to the discussion
+- 1 point: Any response that addresses the original point and is coherent, relevant, and constructive - this includes rebuttals, supporting arguments, additional evidence, clarifying questions, or thoughtful extensions of the discussion
 
-Use Google Search to verify any factual claims in the rebuttal before making your judgement.
+Use Google Search to verify any factual claims in the response before making your judgement.
 
 Return ONLY a valid JSON object in this format:
 {
@@ -565,15 +565,15 @@ CRITICAL: Your explanation must be CRYSTAL CLEAR about why points were awarded. 
 - Why this particular score was given (reference the scoring criteria directly)
 
 Examples of GOOD explanations:
-- "You earned 2 points because you provided factually accurate data from the CDC about vaccination rates and clearly explained how this contradicts the original claim. Your reasoning was logical and well-structured. To earn 3 points, try including more diverse sources and addressing potential counterarguments."
-- "You earned 1 point because your rebuttal directly addresses the original point and shows basic reasoning. However, you didn't provide any sources to back up your claims about economic growth, and some of your assertions need fact-checking. Try including links to authoritative sources next time."
+- "You earned 2 points because you provided factually accurate data from the CDC about vaccination rates and clearly explained how this relates to the original claim. Your reasoning was logical and well-structured. To earn 3 points, try including more diverse sources and addressing potential counterarguments."
+- "You earned 1 point because your response directly addresses the original point and shows clear reasoning. However, you didn't provide any sources to back up your claims about economic growth, and some of your assertions need fact-checking. Try including links to authoritative sources next time."
 
 Examples of BAD explanations:
 - "Good job" (not specific)
 - "Your argument needs work" (not actionable)
 - "This deserves points because it's well-written" (doesn't explain criteria)
 
-Be STINGY with higher points but always award at least 1 point for any coherent, relevant rebuttal. Award 3 points only for rebuttals that demonstrate exceptional research, expert-level knowledge, and comprehensive sourced evidence. Award 2 points only for rebuttals with solid research and strong factual backing. Award 1 point for any rebuttal that addresses the original point and is coherent, relevant, and constructive, even if it lacks extensive research or evidence.
+Be STINGY with higher points but always award at least 1 point for any coherent, relevant response. Award 3 points only for responses that demonstrate exceptional research, expert-level knowledge, and comprehensive sourced evidence. Award 2 points only for responses with solid research and strong factual backing. Award 1 point for any response that addresses the original point and is coherent, relevant, and constructive, even if it lacks extensive research or evidence.
 
 Do not include any explanation or additional text, just the JSON object.`;
 

--- a/branchera/lib/aiService.js
+++ b/branchera/lib/aiService.js
@@ -474,7 +474,7 @@ Do not include any explanation or additional text, just the JSON object.`;
       
       // Return a safe fallback judgement to prevent crashes
       const fallbackJudgement = {
-        pointsEarned: 0,
+        pointsEarned: 1,
         qualityScore: 'none',
         isFactual: false,
         isCoherent: true, // Assume basic coherence if we got this far
@@ -540,14 +540,13 @@ Your job is to evaluate if this rebuttal deserves points based on these criteria
 SCORING SYSTEM (BE VERY STINGY WITH POINTS):
 - 3 points: EXCEPTIONAL rebuttal with comprehensive research, perfect factual accuracy from authoritative sources, sophisticated analysis, and expert-level insight that significantly advances the discussion
 - 2 points: GOOD rebuttal with solid research-backed evidence, strong factual accuracy, clear logical reasoning, and meaningful contribution to the discussion
-- 1 point: BASIC rebuttal that adequately addresses the point with some supporting evidence or reasoning, but lacks depth or comprehensive research
-- 0 points: Does NOT address the original point, OR contains factual inaccuracies, OR is incoherent, irrelevant, unsupported by evidence, or unconstructive
+- 1 point: BASIC rebuttal that adequately addresses the point with some supporting evidence or reasoning, OR any rebuttal that is coherent, relevant, and constructive even if it lacks depth or comprehensive research
 
 Use Google Search to verify any factual claims in the rebuttal before making your judgement.
 
 Return ONLY a valid JSON object in this format:
 {
-  "pointsEarned": 0-3,
+  "pointsEarned": 1-3,
   "qualityScore": "exceptional|good|basic|none",
   "isFactual": true/false,
   "isCoherent": true/false,
@@ -574,7 +573,7 @@ Examples of BAD explanations:
 - "Your argument needs work" (not actionable)
 - "This deserves points because it's well-written" (doesn't explain criteria)
 
-Be EXTREMELY STINGY with points. Award 3 points only for rebuttals that demonstrate exceptional research, expert-level knowledge, and comprehensive sourced evidence. Award 2 points only for rebuttals with solid research and strong factual backing. Award 1 point only for basic but adequate responses. Award 0 points if the rebuttal fails to properly address the original point or lacks sufficient evidence/research.
+Be STINGY with higher points but always award at least 1 point for any coherent, relevant rebuttal. Award 3 points only for rebuttals that demonstrate exceptional research, expert-level knowledge, and comprehensive sourced evidence. Award 2 points only for rebuttals with solid research and strong factual backing. Award 1 point for any rebuttal that addresses the original point and is coherent, relevant, and constructive, even if it lacks extensive research or evidence.
 
 Do not include any explanation or additional text, just the JSON object.`;
 
@@ -609,7 +608,7 @@ Do not include any explanation or additional text, just the JSON object.`;
       
       // Ensure all required properties exist with safe defaults
       const safeJudgement = {
-        pointsEarned: 0,
+        pointsEarned: 1,
         qualityScore: 'none',
         isFactual: false,
         isCoherent: false,
@@ -625,12 +624,12 @@ Do not include any explanation or additional text, just the JSON object.`;
       
       // Validate and fix pointsEarned
       if (typeof safeJudgement.pointsEarned !== 'number' || isNaN(safeJudgement.pointsEarned)) {
-        console.warn('Invalid pointsEarned value, defaulting to 0:', safeJudgement.pointsEarned);
-        safeJudgement.pointsEarned = 0;
+        console.warn('Invalid pointsEarned value, defaulting to 1:', safeJudgement.pointsEarned);
+        safeJudgement.pointsEarned = 1;
       }
       
-      // Ensure points are within valid range
-      safeJudgement.pointsEarned = Math.max(0, Math.min(3, Math.floor(safeJudgement.pointsEarned)));
+      // Ensure points are within valid range (1-3)
+      safeJudgement.pointsEarned = Math.max(1, Math.min(3, Math.floor(safeJudgement.pointsEarned)));
       
       // Validate qualityScore
       const validQualityScores = ['exceptional', 'good', 'basic', 'none'];


### PR DESCRIPTION
Adjust point system to 1-3 range, broaden AI point eligibility to any constructive response, and display earned points in a green UI indicator.

The point range was changed from 0-3 to 1-3 to ensure that any coherent, relevant, and constructive response always earns at least 1 point, thereby encouraging more diverse contributions beyond just rebuttals. The UI now clearly shows the specific points earned in a green indicator for better user feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b0cb87c-66af-4778-a7d1-9ba324b78550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7b0cb87c-66af-4778-a7d1-9ba324b78550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

