### PR TITLE
Fix excessive user points console logging

### DIFF
--- a/branchera/app/dashboard/page.js
+++ b/branchera/app/dashboard/page.js
@@ -116,7 +116,7 @@ export default function DashboardPage() {
       loadCollectedPoints();
     }
     loadPointCounts();
-  }, [user, loadCollectedPoints, loadPointCounts]);
+  }, [user?.uid]); // Only depend on user.uid
 
   useEffect(() => {
     if (!user) {
@@ -203,7 +203,7 @@ export default function DashboardPage() {
       loadCollectedPoints();
     }
     loadPointCounts();
-  }, [user?.uid, loadCollectedPoints, loadPointCounts]);
+  }, [user?.uid]); // Only depend on user.uid, not the functions
 
   const formatDate = (dateString) => {
     const date = new Date(dateString);

--- a/branchera/components/DiscussionFeed.js
+++ b/branchera/components/DiscussionFeed.js
@@ -273,7 +273,7 @@ export default function DiscussionFeed({ newDiscussion, onStartDiscussion }) {
       loadCollectedPoints();
     }
     loadPointCounts();
-  }, [user, loadCollectedPoints, loadPointCounts]);
+  }, [user?.uid]); // Only depend on user.uid
 
   // Handle discussion updates from DiscussionItem components
   const handleDiscussionUpdate = useCallback((discussionId, updatedData) => {

--- a/branchera/hooks/useDatabase.js
+++ b/branchera/hooks/useDatabase.js
@@ -536,8 +536,6 @@ export function useDatabase() {
 
   const getUserPoints = async (userId) => {
     try {
-      console.log('Getting points for user:', userId);
-      
       // Try with orderBy first
       try {
         const points = await getDocuments('userPoints', [
@@ -565,8 +563,6 @@ export function useDatabase() {
 
   const getUserPointsForDiscussion = async (userId, discussionId) => {
     try {
-      console.log('Getting points for user in discussion:', userId, discussionId);
-      
       const allPoints = await getUserPoints(userId);
       return allPoints.filter(point => point.discussionId === discussionId);
     } catch (error) {


### PR DESCRIPTION
Fixes infinite re-rendering loops causing console log spam by updating `useEffect` dependencies and removing excessive logs.

The `useEffect` hooks in `DashboardPage` and `DiscussionFeed` were depending on callback functions that were recreated on every render, leading to continuous execution and repeated "getting points" console messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-49785d81-7117-47e7-bed2-21251e4f6e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49785d81-7117-47e7-bed2-21251e4f6e96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

