### PR TITLE
Prevent mobile input zoom

### DIFF
--- a/branchera/app/globals.css
+++ b/branchera/app/globals.css
@@ -19,6 +19,57 @@ button {
 
 input, textarea {
   font-family: inherit;
+  /* Prevent zoom on mobile devices */
+  font-size: 16px;
+}
+
+/* Ensure all input types have minimum 16px font size to prevent mobile zoom */
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="search"],
+input[type="tel"],
+input[type="url"],
+textarea,
+select {
+  font-size: 16px !important;
+}
+
+/* Prevent zoom on focus for iOS Safari */
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input, textarea, select {
+    font-size: 16px !important;
+  }
+}
+
+/* Additional mobile-specific styles */
+@media screen and (max-width: 768px) {
+  input, textarea, select {
+    font-size: 16px !important;
+    transform: scale(1);
+  }
+  
+  /* Prevent zoom when focusing on input fields */
+  input:focus, textarea:focus, select:focus {
+    transform: scale(1);
+    zoom: 1;
+  }
+}
+
+/* Override any Tailwind text size classes on form elements to prevent mobile zoom */
+input.text-xs, input.text-sm, 
+textarea.text-xs, textarea.text-sm,
+select.text-xs, select.text-sm {
+  font-size: 16px !important;
+}
+
+/* Ensure form elements maintain proper sizing on all mobile devices */
+@supports (-webkit-touch-callout: none) {
+  input, textarea, select {
+    font-size: 16px !important;
+    -webkit-text-size-adjust: 100%;
+  }
 }
 
 /* Prevent long URLs and text from causing horizontal overflow */

--- a/branchera/app/layout.js
+++ b/branchera/app/layout.js
@@ -118,7 +118,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no" />
         
         {/* Apple PWA Meta Tags */}
         <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
Prevent mobile browsers from zooming when focusing on input fields.

Mobile browsers often zoom in on input fields with font sizes smaller than 16px or due to default viewport behaviors, which this PR addresses by updating viewport meta tags and enforcing a minimum 16px font size on all input elements via CSS.

---
<a href="https://cursor.com/background-agent?bcId=bc-44a049bd-10a6-4f47-930e-465da55601a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44a049bd-10a6-4f47-930e-465da55601a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

