### PR TITLE
Add bot tag to AI news posts

### DIFF
--- a/branchera/components/DiscussionItem.js
+++ b/branchera/components/DiscussionItem.js
@@ -407,6 +407,8 @@ export default function DiscussionItem({
                     className={`inline-block px-2 py-0.5 text-xs rounded-full font-medium ${
                       tag === 'News' 
                         ? 'bg-red-100 text-red-800 border border-red-200' 
+                        : tag === 'Bot'
+                        ? 'bg-blue-100 text-blue-800 border border-blue-200'
                         : 'bg-gray-100 text-gray-600 border border-gray-200'
                     }`}
                   >
@@ -489,6 +491,8 @@ export default function DiscussionItem({
                     className={`inline-block px-2 py-0.5 text-xs rounded-full font-medium ${
                       tag === 'News' 
                         ? 'bg-red-100 text-red-800 border border-red-200' 
+                        : tag === 'Bot'
+                        ? 'bg-blue-100 text-blue-800 border border-blue-200'
                         : 'bg-gray-100 text-gray-600 border border-gray-200'
                     }`}
                   >
@@ -573,6 +577,8 @@ export default function DiscussionItem({
                   className={`inline-block px-3 py-1 text-xs rounded-full font-medium ${
                     tag === 'News' 
                       ? 'bg-red-100 text-red-800 border border-red-200' 
+                      : tag === 'Bot'
+                      ? 'bg-blue-100 text-blue-800 border border-blue-200'
                       : 'bg-gray-100 text-gray-700 border border-gray-200'
                   }`}
                 >

--- a/branchera/components/SearchFilterSort.js
+++ b/branchera/components/SearchFilterSort.js
@@ -597,9 +597,13 @@ export default function SearchFilterSort({
                           isSelected
                             ? tag === 'News'
                               ? 'bg-red-100 text-red-800 border-red-300 hover:bg-red-200'
+                              : tag === 'Bot'
+                              ? 'bg-blue-100 text-blue-800 border-blue-300 hover:bg-blue-200'
                               : 'bg-black text-white border-black hover:bg-black/80'
                             : tag === 'News'
                               ? 'bg-white text-red-600 border-red-200 hover:bg-red-50'
+                              : tag === 'Bot'
+                              ? 'bg-white text-blue-600 border-blue-200 hover:bg-blue-50'
                               : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
                         }`}
                       >

--- a/branchera/lib/newsService.js
+++ b/branchera/lib/newsService.js
@@ -437,7 +437,7 @@ Make it punchy, specific, and debate-worthy. The source information will be disp
       
       // Create more specific tags based on category
       const generateTags = (category, story) => {
-        const baseTags = ['News'];
+        const baseTags = ['News', 'Bot'];
         
         // Add category-specific tags
         switch (category?.toLowerCase()) {


### PR DESCRIPTION
Add a "Bot" tag to AI news posts and apply distinct styling to clearly identify AI-generated content.

---
<a href="https://cursor.com/background-agent?bcId=bc-93b13519-3599-41bb-9a71-29e206cdd797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93b13519-3599-41bb-9a71-29e206cdd797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

