### PR TITLE
Fix point system claim logic

### DIFF
--- a/branchera/components/TextReplyForm.js
+++ b/branchera/components/TextReplyForm.js
@@ -31,7 +31,7 @@ export default function TextReplyForm({
   const [isJudging, setIsJudging] = useState(false);
 
   const { user, getDisplayName } = useAuth();
-  const { addReply, updateReplyFactCheckResults, createUserPoint, hasUserEarnedPointsForDiscussion } = useDatabase();
+  const { addReply, updateReplyFactCheckResults, createUserPoint, hasUserCollectedPoint } = useDatabase();
 
   // Safely get toast functions with fallbacks
   const toastContext = useToast();
@@ -106,10 +106,10 @@ export default function TextReplyForm({
       // Check if this is a rebuttal to a specific point and if user can earn points
       if (selectedPoint && selectedPoint.text) {
         try {
-          // Check if user has already earned points for this discussion
-          const hasEarnedPoints = await hasUserEarnedPointsForDiscussion(user.uid, discussionId);
+          // Check if user has already collected points for this specific point
+          const hasCollectedThisPoint = await hasUserCollectedPoint(user.uid, discussionId, selectedPoint.id);
 
-          if (!hasEarnedPoints) {
+          if (!hasCollectedThisPoint) {
             setIsJudging(true);
             console.log('Judging rebuttal for points...');
 
@@ -214,11 +214,11 @@ export default function TextReplyForm({
               }
             }
           } else {
-            console.log('User has already earned points for this discussion');
-            // Show info toast for already earned points
+            console.log('User has already collected points for this specific point');
+            // Show info toast for already collected point
             try {
               if (showSuccessToast && typeof showSuccessToast === 'function') {
-                showSuccessToast('Reply submitted!', 3000);
+                showSuccessToast('Reply submitted! You\'ve already claimed points for this specific claim.', 4000);
               }
             } catch (toastError) {
               console.error('Error showing info toast:', toastError);


### PR DESCRIPTION
Fixes a bug preventing users from claiming multiple points within the same discussion by checking for specific point claims instead of discussion-wide point earnings.

The `TextReplyForm` component was incorrectly using `hasUserEarnedPointsForDiscussion` to determine if a user could claim a point. This function checked if the user had earned *any* points for the entire discussion, thus blocking subsequent claims for different points within the same discussion. The fix replaces this with `hasUserCollectedPoint`, which correctly checks if the user has already claimed the *specific* point they are attempting to claim, allowing multiple distinct point claims per discussion.

---
<a href="https://cursor.com/background-agent?bcId=bc-37348963-befe-421b-a79a-baa9a9e44edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37348963-befe-421b-a79a-baa9a9e44edf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

