### PR TITLE
Center reply button icon on small screens

### DIFF
--- a/branchera/components/DiscussionItem.js
+++ b/branchera/components/DiscussionItem.js
@@ -657,7 +657,7 @@ export default function DiscussionItem({
           {user && (
             <button
               onClick={handleStartReply}
-              className="absolute bottom-3 right-3 bg-black text-white p-2 rounded-full shadow-lg hover:bg-gray-800 transition-colors z-10"
+              className="absolute bottom-3 right-3 bg-black text-white p-2 rounded-full shadow-lg hover:bg-gray-800 transition-colors z-10 flex items-center justify-center"
               title="Reply to discussion"
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
Fixes off-center '+' icon in the floating reply button on small screens by adding flex centering classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-20504acd-46f0-4a18-ae17-526f2ee0256c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20504acd-46f0-4a18-ae17-526f2ee0256c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

