### PR TITLE
Fix logo loading due to cache

### DIFF
--- a/branchera/app/layout.js
+++ b/branchera/app/layout.js
@@ -136,7 +136,7 @@ export default function RootLayout({ children }) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes" />
 
         {/* Preload critical resources */}
-        <link rel="preload" href="/logo.svg" as="image" type="image/svg+xml" />
+        <link rel="preload" href="/logo.svg?v=3" as="image" type="image/svg+xml" />
         <link rel="preload" href="/manifest.json" as="fetch" crossOrigin="anonymous" />
         
         {/* DNS prefetch for external domains */}

--- a/branchera/app/login/page.js
+++ b/branchera/app/login/page.js
@@ -28,7 +28,7 @@ export default function LoginPage() {
         <div className="text-center mb-8">
           <div className="flex items-center justify-center mb-2">
             <Image
-              src="/logo.svg"
+              src="/logo.svg?v=3"
               alt="Branches Logo"
               width={96}
               height={96}

--- a/branchera/app/page.js
+++ b/branchera/app/page.js
@@ -44,7 +44,7 @@ export default function Home() {
               "name": "Branches",
               "logo": {
                 "@type": "ImageObject",
-                "url": "https://branches.live/logo.svg"
+                "url": "https://branches.live/logo.svg?v=3"
               }
             }
           })
@@ -58,7 +58,7 @@ export default function Home() {
             
             <div className="flex items-center justify-center mb-6 md:mb-8">
               <Image
-                src="/logo.svg"
+                src="/logo.svg?v=3"
                 alt="Branches Logo"
                 width={96}
                 height={96}

--- a/branchera/components/TopNav.js
+++ b/branchera/components/TopNav.js
@@ -56,7 +56,7 @@ export default function TopNav() {
             className="flex items-center text-xl font-bold text-gray-900 hover:text-gray-600 transition-colors"
           >
             <Image 
-              src="/logo.svg" 
+              src="/logo.svg?v=3" 
               alt="Branches Logo" 
               width={32}
               height={32}

--- a/branchera/public/sw.js
+++ b/branchera/public/sw.js
@@ -1,12 +1,12 @@
-const CACHE_NAME = 'branches-v2';
-const STATIC_CACHE = 'branches-static-v2';
-const DYNAMIC_CACHE = 'branches-dynamic-v2';
+const CACHE_NAME = 'branches-v3';
+const STATIC_CACHE = 'branches-static-v3';
+const DYNAMIC_CACHE = 'branches-dynamic-v3';
 
 // Critical resources to cache immediately
 const STATIC_ASSETS = [
   '/',
   '/manifest.json',
-  '/logo.svg',
+  '/logo.svg?v=3',
   '/icon-192.png',
   '/icon-512.png',
   '/apple-touch-icon.png',


### PR DESCRIPTION
Update service worker cache version and add cache-busting to logo URLs to fix the logo not loading due to aggressive caching.

The logo was aggressively cached by the service worker, browser, and Next.js image optimization, preventing recent updates from being displayed. This change increments the service worker cache version and adds a `?v=3` parameter to all logo references, ensuring a fresh fetch for the updated logo.

---
<a href="https://cursor.com/background-agent?bcId=bc-06cbf331-912f-4599-97b3-f2769ea5cb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06cbf331-912f-4599-97b3-f2769ea5cb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

