### PR TITLE
Fix reply button shape on small screens

### DIFF
--- a/branchera/components/DiscussionDialog.js
+++ b/branchera/components/DiscussionDialog.js
@@ -69,7 +69,7 @@ export default function DiscussionDialog({ isOpen, onClose, onDiscussionCreated 
           <h2 className="text-xl font-bold text-gray-900">Start a Discussion</h2>
           <button
             onClick={onClose}
-            className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+            className="w-9 h-9 flex items-center justify-center hover:bg-gray-100 rounded-full transition-colors"
             aria-label="Close dialog"
           >
             <svg className="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/branchera/components/DiscussionItem.js
+++ b/branchera/components/DiscussionItem.js
@@ -657,7 +657,7 @@ export default function DiscussionItem({
           {user && (
             <button
               onClick={handleStartReply}
-              className="absolute bottom-3 right-3 bg-black text-white p-2 rounded-full shadow-lg hover:bg-gray-800 transition-colors z-10 flex items-center justify-center"
+              className="absolute bottom-3 right-3 w-10 h-10 bg-black text-white rounded-full shadow-lg hover:bg-gray-800 transition-colors z-10 flex items-center justify-center"
               title="Reply to discussion"
             >
               <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
Add explicit width and height to circular buttons to ensure they maintain their shape on smaller screens.

The "reply" and "close" buttons were not consistently staying circular on smaller screens because they relied only on padding (`p-2`) and `rounded-full` for their shape. Adding explicit `w-X h-X` classes ensures they maintain a perfect circular form across all screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2538672-32a9-4d66-9fc2-54461a81dfd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2538672-32a9-4d66-9fc2-54461a81dfd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

