### PR TITLE
Debug service worker response clone error

### DIFF
--- a/branchera/public/sw.js
+++ b/branchera/public/sw.js
@@ -115,8 +115,11 @@ async function staleWhileRevalidate(request) {
   
   const fetchPromise = fetch(request).then((networkResponse) => {
     if (networkResponse.ok) {
-      const cache = caches.open(DYNAMIC_CACHE);
-      cache.then((c) => c.put(request, networkResponse.clone()));
+      // Clone the response before using it
+      const responseToCache = networkResponse.clone();
+      caches.open(DYNAMIC_CACHE).then((cache) => {
+        cache.put(request, responseToCache);
+      });
     }
     return networkResponse;
   }).catch(() => cachedResponse);


### PR DESCRIPTION
Fix `TypeError: Failed to execute 'clone' on 'Response'` in `sw.js` by cloning the network response immediately before caching.

The `staleWhileRevalidate` strategy was attempting to clone a `networkResponse` after it might have already been consumed (e.g., by being returned from the `fetch` promise). Response bodies can only be read once, so cloning it upfront ensures a fresh copy is available for caching.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e969bcd-1f57-4e55-a4be-baf9a20d06d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9e969bcd-1f57-4e55-a4be-baf9a20d06d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

