### PR TITLE
Fix discussion pages in nextjs sitemap

### DIFF
--- a/branchera/app/sitemap.js
+++ b/branchera/app/sitemap.js
@@ -45,6 +45,7 @@ export default async function sitemap() {
   let discussionPages = [];
   try {
     const discussions = await getAllDiscussionSlugs();
+    console.log(`[Sitemap] Found ${discussions.length} discussions to include in sitemap`);
     discussionPages = discussions.map((discussion) => ({
       url: `${baseUrl}/discussion/${discussion.slug}`,
       lastModified: new Date(),
@@ -52,8 +53,9 @@ export default async function sitemap() {
       priority: 0.8,
     }));
   } catch (error) {
-    console.error('Error generating sitemap for discussions:', error);
+    console.error('[Sitemap] Error generating sitemap for discussions:', error);
   }
 
+  console.log(`[Sitemap] Total pages in sitemap: ${staticPages.length + discussionPages.length} (${staticPages.length} static, ${discussionPages.length} discussions)`);
   return [...staticPages, ...discussionPages];
 }

--- a/branchera/lib/discussionServer.js
+++ b/branchera/lib/discussionServer.js
@@ -3,7 +3,7 @@
  * These functions run on the server and can be used in Server Components
  */
 
-import { db } from './firebase';
+import { getFirestoreInstance } from './firebase.js';
 import { collection, query, where, getDocs, limit as firestoreLimit } from 'firebase/firestore';
 
 /**
@@ -14,6 +14,13 @@ import { collection, query, where, getDocs, limit as firestoreLimit } from 'fire
 export async function getDiscussionBySlugServer(slug) {
   try {
     if (!slug) {
+      return null;
+    }
+
+    // Get Firestore instance
+    const db = await getFirestoreInstance();
+    if (!db) {
+      console.error('Firestore instance not available');
       return null;
     }
 
@@ -48,6 +55,13 @@ export async function getDiscussionBySlugServer(slug) {
  */
 export async function getAllDiscussionSlugs() {
   try {
+    // Get Firestore instance
+    const db = await getFirestoreInstance();
+    if (!db) {
+      console.error('Firestore instance not available');
+      return [];
+    }
+
     const discussionsRef = collection(db, 'discussions');
     const querySnapshot = await getDocs(discussionsRef);
 


### PR DESCRIPTION
Include generated discussion pages in the Next.js sitemap by ensuring the Firestore instance is properly initialized during server-side rendering.

Previously, the `db` export from `firebase.js` was lazily initialized and could be `null` when `discussionServer.js` functions (like `getAllDiscussionSlugs`) were called during the server-side sitemap generation process. This PR updates `discussionServer.js` to explicitly await `getFirestoreInstance()`, guaranteeing that the Firestore client is ready before attempting to fetch data.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddf50049-26d8-4912-8323-da6e4276db83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddf50049-26d8-4912-8323-da6e4276db83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

